### PR TITLE
request destructured on entry

### DIFF
--- a/server/routes/campgrounds.js
+++ b/server/routes/campgrounds.js
@@ -5,10 +5,11 @@ router.get('/', (req, res) => {
     res.send('Campgrounds routes are connected.');
 });
 
-router.get('/:id', async (req, res) => {
-    const { id } = req.params;
-    const data = await Campground.findById(id);
-    return res.json(data);
+router.get('/:id', async ({ params, body }, res) => {
+    const { id } = params;
+    console.log('The request id is:', id);
+    // const data = await Campground.findById(id);
+    // return res.json(data);
 })
 
 module.exports = router;


### PR DESCRIPTION
The body and params are destructured in the campgrounds/:id route to more easily access the data needed from the request.